### PR TITLE
Minor rewording

### DIFF
--- a/docs/03-AcceptanceTests.md
+++ b/docs/03-AcceptanceTests.md
@@ -332,8 +332,8 @@ modules:
         - \Helper\Acceptance
 ```
 
-In order to run browser tests you will need Selenium Server or PhantomJS. 
-WebDriver module contains a manual on [how to start them](http://codeception.com/docs/modules/WebDriver#Local-Testing).
+In order to run browser tests you will need Selenium Server or PhantomJS.
+See [WebDriver module](http://codeception.com/docs/modules/WebDriver) for details.
 
 Please note that actions executed in a browser will behave differently. For instance, `seeElement` won't just check that the element exists on a page,
 but it will also check that element is actually visible to the user:
@@ -344,7 +344,7 @@ $I->seeElement('#modal');
 ```
 
 While WebDriver duplicate the functionality of PhpBrowser it has its limitations: it can't check headers, perform HTTP requests, as browsers don't provide APIs for that. 
-WebDriver also adds browser-specific functionality which will be listed in next sections.
+WebDriver also adds browser-specific functionality:
 
 #### Wait
 


### PR DESCRIPTION
Question: When using PhantomJS, Selenium is not involved at all, right? If true, the heading "Selenium WebDriver" is misleading and should be changed to "WedDriver (Selenium or PhantomJS)", plus some similar changes at http://codeception.com/docs/modules/WebDriver